### PR TITLE
feat: add analyzer-only compile mode (-COMPILEANA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,13 @@ DLLs that the engine `LoadLibrary`s at runtime — the analyzer runs
 entirely from compiled code, so source edits to `.nlp` files between
 runs don't affect the output until you recompile.
 
-| Script | What it does | Output |
-|--------|--------------|--------|
-| [`scripts/compile-analyzer.ps1`](scripts/compile-analyzer.ps1) | Runs `nlp.exe -COMPILE` (emits the analyzer C++ trees under `<analyzer>\run` and `<analyzer>\kb`), then links everything into a single DLL against `compile-libs/`. The DLL exports both `run_analyzer(Parse*)` and `kb_setup(void*)` (engine codegen emits both). | `<analyzer>\bin\run.dll`<br>`<analyzer>\bin\runu.dll`<br>`<analyzer>\bin\kb.dll`<br>`<analyzer>\bin\kbu.dll` |
+| Mode | Flag | What it does | Output |
+|------|------|--------------|--------|
+| Full (default) | `-COMPILE` | Runs `nlp.exe -COMPILE` (emits the analyzer C++ trees under `<analyzer>\run` and `<analyzer>\kb`), then links everything into a single DLL against `compile-libs/`. The DLL exports both `run_analyzer(Parse*)` and `kb_setup(void*)` (engine codegen emits both). | `<analyzer>\bin\run.dll`<br>`<analyzer>\bin\runu.dll`<br>`<analyzer>\bin\kb.dll`<br>`<analyzer>\bin\kbu.dll` |
+| KB only | `-KbOnly` (`-COMPILEKB`) | Compiles only the knowledge base. Use when only the KB changed. | `<analyzer>\bin\kb.dll`<br>`<analyzer>\bin\kbu.dll` |
+| Analyzer only | `-AnalyzerOnly` (`-COMPILEANA`) | Compiles only the analyzer rules, leaving any existing `kb.dll` in place. Use when only the rules changed and the KB is already compiled. | `<analyzer>\bin\run.dll`<br>`<analyzer>\bin\runu.dll` |
+
+[`scripts/compile-analyzer.ps1`](scripts/compile-analyzer.ps1) drives all three modes.
 
 The same DLL is staged under all four filenames so the engine's
 load paths find it whether it's looking for the ANSI or UNICODE
@@ -111,8 +115,12 @@ script can be run either directly from PowerShell or from `cmd.exe`.
 # Or from cmd.exe via the .bat shim:
 scripts\compile-analyzer.bat data\rfb data\rfb\input\text.txt
 
-# Legacy: KB-only compile (matches the pre-NLP-ENGINE-WINDOWS-007 behaviour):
+# KB-only compile (-COMPILEKB): rebuild just kb.dll / kbu.dll:
 .\scripts\compile-analyzer.ps1 -KbOnly data\rfb data\rfb\input\text.txt
+
+# Analyzer-only compile (-COMPILEANA): rebuild just run.dll / runu.dll,
+# leaving the existing kb.dll in place. Use when only the rules changed:
+.\scripts\compile-analyzer.ps1 -AnalyzerOnly data\rfb data\rfb\input\text.txt
 
 # Run with the compiled artifacts:
 .\nlp.exe -COMPILED -ANA data\rfb -WORK . data\rfb\input\text.txt

--- a/scripts/compile-analyzer.ps1
+++ b/scripts/compile-analyzer.ps1
@@ -15,9 +15,16 @@
   and bin\kbu.dll. Without it (default), the full analyzer is compiled
   and bin\run.dll / bin\runu.dll are produced too.
 
+.PARAMETER AnalyzerOnly
+  If set, build only the analyzer rules (-COMPILEANA) — produces just
+  bin\run.dll and bin\runu.dll, leaving any existing bin\kb.dll in place.
+  Use when only the rules changed and the KB is already compiled. Mutually
+  exclusive with -KbOnly.
+
 .EXAMPLE
   scripts\compile-analyzer.ps1 data\rfb data\rfb\input\text.txt
   scripts\compile-analyzer.ps1 -KbOnly data\rfb data\rfb\input\text.txt
+  scripts\compile-analyzer.ps1 -AnalyzerOnly data\rfb data\rfb\input\text.txt
 
 .NOTES
   Requires Visual Studio 2022 (or Build Tools) with the "Desktop development
@@ -34,13 +41,18 @@
   Output (-KbOnly):
     <AnalyzerDir>\bin\kb.dll
     <AnalyzerDir>\bin\kbu.dll
+
+  Output (-AnalyzerOnly):
+    <AnalyzerDir>\bin\run.dll
+    <AnalyzerDir>\bin\runu.dll
 #>
 
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true, Position = 0)] [string] $AnalyzerDir,
     [Parameter(Mandatory = $true, Position = 1)] [string] $InputFile,
-    [switch] $KbOnly
+    [switch] $KbOnly,
+    [switch] $AnalyzerOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -62,10 +74,17 @@ if (-not (Test-Path $InputFile)) {
 }
 $InputFile = (Resolve-Path $InputFile).Path
 
+if ($KbOnly -and $AnalyzerOnly) {
+    throw "Specify at most one of -KbOnly or -AnalyzerOnly."
+}
 if ($KbOnly) {
     $CompileFlag = '-COMPILEKB'
     $TargetName  = 'nlp_kb'
     $SrcGlobDesc = 'kb'
+} elseif ($AnalyzerOnly) {
+    $CompileFlag = '-COMPILEANA'
+    $TargetName  = 'nlp_run'
+    $SrcGlobDesc = 'run'
 } else {
     $CompileFlag = '-COMPILE'
     $TargetName  = 'nlp_analyzer'
@@ -237,6 +256,8 @@ $cmakeLibDir    = (Join-Path $CompileLibs 'lib')          -replace '\\', '/'
 
 if ($KbOnly) {
     $globExpr = "`"$cmakeAnalyzer/kb/*.cpp`""
+} elseif ($AnalyzerOnly) {
+    $globExpr = "`"$cmakeAnalyzer/run/*.cpp`""
 } else {
     $globExpr = "`"$cmakeAnalyzer/run/*.cpp`" `"$cmakeAnalyzer/kb/*.cpp`""
 }
@@ -310,6 +331,8 @@ if (-not (Test-Path $builtDll)) {
 
 if ($KbOnly) {
     $stagedNames = @('kb.dll', 'kbu.dll')
+} elseif ($AnalyzerOnly) {
+    $stagedNames = @('run.dll', 'runu.dll')
 } else {
     $stagedNames = @('run.dll', 'runu.dll', 'kb.dll', 'kbu.dll')
 }


### PR DESCRIPTION
Adds a third compile mode (`-AnalyzerOnly` → `-COMPILEANA`) to `scripts/compile-analyzer` matching nlp-engine 3.6.0, alongside the default full build and KB-only. Builds and stages only `run.dll` / `runu.dll`, leaving any existing `kb.dll` in place — for when only the rules changed and the KB is already compiled. README updated.

Follow-up: bump the `python` submodule once VisualText/python#4 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)